### PR TITLE
add count-matches functionality compatible with GNU uniq

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ As an example, consider the file test.txt:
 	Return of the King
 	Teh return of theking
 
-Running funiq on this list and telling it to ignore casing (-i) and non-alphanumeric characters (-c)
+Running funiq on this list and telling it to ignore casing (-i) and non-alphanumeric characters (-I)
 
-	$ funiq -ci test.txt
+	$ funiq -iI test.txt
 
 Results in:
 
@@ -27,7 +27,7 @@ Results in:
 
 Which is ok, but it hasn't produced the desired results with The Fellowship of the Ring. Using the -d option, we can increase the threshold at which matches are considered (default is 3):
 
-	$ funiq -ci -d 4 test.txt
+	$ funiq -iI -d 4 test.txt
 
 	The Fellowship of The Ring
 	The Return of the King

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Funiq can read from a file or have its input piped from stdin.
 
 	USAGE: 
 
-     funiq  [-c] [-t] [-a] [-i] [-d <integer>] [--] [--version] [-h]
+     funiq  [-c] [-a] [-i] [-I] [-d <integer>] [--] [--version] [-h]
                 <filename>
 
 

--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ Funiq can read from a file or have its input piped from stdin.
 
 	Where: 
 
-	   -c,  --ignore-non-alpha-numeric
+	   -I,  --ignore-non-alpha-numeric
 	     When active, non-alphanumeric characters do not contribute to edit
 	     distance.
 
-	   -t,  --show-totals
-	     Shows total number of matches per item
+	   -c,  --show-counts
+	     Precede each output line with the count of the number of times the line occurred
+	     in the input, followed by a single space.
 
 	   -a,  --show-all
 	     Will show all found duplicates
@@ -60,6 +61,7 @@ Funiq can read from a file or have its input piped from stdin.
 
 	   -d <integer>,  --distance <integer>
 	     Maximum edit distance between two strings to be considered a match.
+	     Default: 3
 
 	   --,  --ignore_rest
 	     Ignores the rest of the labeled arguments following this flag.

--- a/lib/funiq/Matcher.h
+++ b/lib/funiq/Matcher.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <string>
 #include <iostream>
+#include <iomanip>
 #include <functional>
 #include <cctype>
 #include <map>
@@ -60,12 +61,17 @@ void Matcher::add(std::string line) {
 	}
 }
 
+// todo: count max width necessary
 void Matcher::show(std::ostream* output) {
 	for(auto matchPair : *matchMap) {
 		StringList v = *matchPair.second;
 		bool first = true;
 		for(std::string matchItem : v) {
 			if(first || _settings.showAllMatches) {
+				if(first && _settings.showTotals)
+					*output << 
+						std::setw(_settings.totalsFieldWidth) <<
+						v.size() << " "; // space for compatibility with GNU uniq
 				if(!first) *output << "\t";
 				*output << matchItem;
 				first = false;

--- a/lib/funiq/Matcher.h
+++ b/lib/funiq/Matcher.h
@@ -11,6 +11,8 @@
 
 #include "Settings.h"
 
+#define TOTALS_FIELD_WIDTH 7 // count-field width 7 used by GNU uniq
+
 typedef std::vector<std::string> StringList;
 typedef std::map< std::string, StringList* > StringListMap;
 
@@ -70,7 +72,7 @@ void Matcher::show(std::ostream* output) {
 			if(first || _settings.showAllMatches) {
 				if(first && _settings.showTotals)
 					*output << 
-						std::setw(_settings.totalsFieldWidth) <<
+						std::setw(TOTALS_FIELD_WIDTH) <<
 						v.size() << " "; // space for compatibility with GNU uniq
 				if(!first) *output << "\t";
 				*output << matchItem;

--- a/lib/funiq/Settings.h
+++ b/lib/funiq/Settings.h
@@ -8,8 +8,8 @@ struct Settings
 		caseInsensitive(false),
 		showAllMatches(false),
 		showTotals(false),
-		ignoreNonAlphaNumeric(false),
-		totalsFieldWidth(7){} // count-field width 7 used by GNU uniq
+		ignoreNonAlphaNumeric(false)
+		{}
 
 	unsigned int maxEditDistance;
 	bool caseInsensitive;

--- a/lib/funiq/Settings.h
+++ b/lib/funiq/Settings.h
@@ -8,13 +8,15 @@ struct Settings
 		caseInsensitive(false),
 		showAllMatches(false),
 		showTotals(false),
-		ignoreNonAlphaNumeric(false){}
+		ignoreNonAlphaNumeric(false),
+		totalsFieldWidth(7){} // count-field width 7 used by GNU uniq
 
 	unsigned int maxEditDistance;
 	bool caseInsensitive;
 	bool showAllMatches;
 	bool showTotals;
 	bool ignoreNonAlphaNumeric;
+	int totalsFieldWidth;
 };
 
 #endif

--- a/src/funiq.cpp
+++ b/src/funiq.cpp
@@ -68,7 +68,7 @@ int main(int argc, char* argv[]) {
 		std::string filename;
 		Settings settings;
 		parseCommandLine(argc, argv, filename, settings);
-		
+
 		Matcher matcher(settings);
 		std::istream* inputStream = getInput(filename);		
 		for (std::string line; getline(*inputStream, line); ) {

--- a/src/funiq.cpp
+++ b/src/funiq.cpp
@@ -12,7 +12,7 @@
 
 void parseCommandLine(int argc, char** argv, std::string& filename, Settings& settings) {
 	
-		TCLAP::CmdLine cmd("funiq - Fuzzy Unique Filtering", ' ', "0.1");
+		TCLAP::CmdLine cmd("funiq - Fuzzy Unique Filtering", ' ', "0.2");
 	
 	TCLAP::UnlabeledValueArg<std::string> filenameArg (
 		"filename",
@@ -29,10 +29,10 @@ void parseCommandLine(int argc, char** argv, std::string& filename, Settings& se
 		"a","show-all",
 		"Will show all found duplicates");
 	TCLAP::SwitchArg showTotalsSwitch(
-		"t","show-totals",
-		"Shows total number of matches per item");
+		"c","show-counts",
+		"Precede each output line with the count of the number of times the line occurredin the input, followed by a single space.");
 	TCLAP::SwitchArg ignoreNonAlphaNumericSwitch(
-		"c","ignore-non-alpha-numeric",
+		"I","ignore-non-alpha-numeric",
 		"When active, non-alphanumeric characters do not contribute to edit distance.");
 	
 	cmd.add(filenameArg);


### PR DESCRIPTION
I added GNU uniq-compatible match counts.
* space is used as count-field separator, regardless of -a flag, which use \t
* used -c for command-line flag instead of -t
* changed ignore-nonalphanumeric to the more-mnemonic and non-conflicting -I (parallel with -i for ignore-case)

In tests for my use case (searching logfiles for similar lines) this now performs as a drop-in replacement for uniq.