### PR TITLE
Allow normalized Levenshtein comparison method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [0.3.0] - 2020-01-27
+
+Note - we've adopted semantic versioning from this point forward.
+
+### Added
+- Ability to use Normalized Levenshtein Distance (suggested by [@ComedyTomedy](https://github.com/ComedyTomedy)) via the`--method` flag
+
+## [0.2] - 2018-05-24
+
+### Changed
+- Made count behaviour compatible with GNU uniq. Flag for showing totals is now (`-c`), and the spacing between the totals column and the results column is now rendered with spaces instead of tabs. Contributed by [@sehrgut](https://github.com/sehrgut)
+
+## [0.1] - 2014-03-17
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ Funiq can read from a file or have its input piped from stdin.
     
        -c,  --show-counts
          Precede each output line with the count of the number of times the
-         line occurredin the input, followed by a single space.
+         line occurred in the input, followed by a single space.
     
        -a,  --show-all
          Will show all found duplicates
     
        -i,  --case-insensitive
-         When active, case differences do not contribute to edit distance.
+         When active, case differences do not contribute to distance between
+         strings.
     
        -d <number>,  --distance <number>
          Maximum distance threshold between two strings to be considered

--- a/README.md
+++ b/README.md
@@ -37,46 +37,57 @@ Which is what we were looking for.
 
 Funiq can read from a file or have its input piped from stdin.
 
-	USAGE: 
-
-     funiq  [-c] [-a] [-i] [-I] [-d <integer>] [--] [--version] [-h]
-                <filename>
-
-
-	Where: 
-
-	   -I,  --ignore-non-alpha-numeric
-	     When active, non-alphanumeric characters do not contribute to edit
-	     distance.
-
-	   -c,  --show-counts
-	     Precede each output line with the count of the number of times the line occurred
-	     in the input, followed by a single space.
-
-	   -a,  --show-all
-	     Will show all found duplicates
-
-	   -i,  --case-insensitive
-	     When active, case differences do not contribute to edit distance.
-
-	   -d <integer>,  --distance <integer>
-	     Maximum edit distance between two strings to be considered a match.
-	     Default: 3
-
-	   --,  --ignore_rest
-	     Ignores the rest of the labeled arguments following this flag.
-
-	   --version
-	     Displays version information and exits.
-
-	   -h,  --help
-	     Displays usage information and exits.
-
-	   <filename>
-	     File to read. If omitted will read from stdin.
-
-
-	   funiq - Fuzzy Unique Filtering
+    USAGE: 
+    
+       bin/funiq  [-I] [-c] [-a] [-i] [-d <number>] [-m <levenshtein
+                  |normalized-levenshtein>] [--] [--version] [-h] <filename>
+    
+    
+    Where: 
+    
+       -I,  --ignore-non-alpha-numeric
+         When active, non-alphanumeric characters do not contribute to edit
+         distance.
+    
+       -c,  --show-counts
+         Precede each output line with the count of the number of times the
+         line occurredin the input, followed by a single space.
+    
+       -a,  --show-all
+         Will show all found duplicates
+    
+       -i,  --case-insensitive
+         When active, case differences do not contribute to edit distance.
+    
+       -d <number>,  --distance <number>
+         Maximum distance threshold between two strings to be considered
+         duplicates.
+    
+         For the default Levenshtein comparison method, it is the maximum edit
+         distance allowed for two strings to be considered duplicates.
+    
+         For the Normalized Levenshtein comparison method, it is a number
+         between 0.0 and 1.0 representing 0% and 100% similarity respectively.
+    
+       -m <levenshtein|normalized-levenshtein>,  --method <levenshtein
+          |normalized-levenshtein>
+         The method used to compare similarity of strings. Defaults to
+         'levenshtein'
+    
+       --,  --ignore_rest
+         Ignores the rest of the labeled arguments following this flag.
+    
+       --version
+         Displays version information and exits.
+    
+       -h,  --help
+         Displays usage information and exits.
+    
+       <filename>
+         File to read. If omitted will read from stdin.
+    
+    
+       funiq - Fuzzy Unique Filtering
 
 # Installation
 

--- a/lib/funiq/Matcher.h
+++ b/lib/funiq/Matcher.h
@@ -16,6 +16,7 @@
 typedef std::vector<std::string> StringList;
 typedef std::map< std::string, StringList* > StringListMap;
 
+
 class Matcher{
 public:
 	Matcher(Settings& settings);
@@ -27,7 +28,9 @@ private:
 	StringListMap* matchMap;
 	void lowercase(std::string& s);
 	void removeNonAlphaNumeric(std::string& s);
+	bool isMatch(const std::string& s1, const std::string& s2);
 	unsigned int levenshteinDistance(const std::string& s1, const std::string& s2);
+	float normalizedLevenshtein(const std::string& s1, const std::string& s2);
 };
 
 Matcher::Matcher(Settings& settings):_settings(settings) {
@@ -49,7 +52,7 @@ void Matcher::add(std::string line) {
 		if(_settings.caseInsensitive) lowercase(normalizedKey);
 		if(_settings.ignoreNonAlphaNumeric) removeNonAlphaNumeric(normalizedKey);
 		StringList* matchList = matchPair.second;	
-		if(levenshteinDistance(normalizedLine, normalizedKey) <= _settings.maxEditDistance) {
+		if(isMatch(normalizedLine, normalizedKey)) {
 			matchFound = true;
 			matchList->push_back(normalizedLine);
 			continue;
@@ -89,12 +92,25 @@ void Matcher::lowercase(std::string& s) {
 
 void Matcher::removeNonAlphaNumeric(std::string& s) {
 	s.erase(std::remove_if(s.begin(), s.end(), [](const char& c){
-                return !std::isalnum(c);
-              }), s.end());
+				return !std::isalnum(c);
+			  }), s.end());
+}
+
+bool Matcher::isMatch(const std::string& s1, const std::string& s2) {
+	if (_settings.comparisonMethod == NormalizedLevenshtein) {
+		return normalizedLevenshtein(s1, s2) <= _settings.maxDistance;
+	}
+	return levenshteinDistance(s1, s2) <= _settings.maxDistance;
+}
+
+float Matcher::normalizedLevenshtein(const std::string& s1, const std::string& s2) {
+	int editDistance = levenshteinDistance(s1, s2);
+	int maxLength = std::max(s1.length(), s2.length());
+	float res = (float)editDistance / (float)maxLength;
+	return res;
 }
 
 unsigned int Matcher::levenshteinDistance(const std::string& s1, const std::string& s2) {
-	
 	unsigned int len1 = s1.size();
 	unsigned int len2 = s2.size();
 	std::vector<unsigned int> col(len2+1);

--- a/lib/funiq/Settings.h
+++ b/lib/funiq/Settings.h
@@ -1,18 +1,22 @@
 #ifndef _FUNIQ_SETTINGS_
 #define _FUNIQ_SETTINGS_
 
+enum ComparisonMethod { Levenshtein, NormalizedLevenshtein };
+
 struct Settings
 {
 	Settings() :
-		maxEditDistance(3),
+		maxDistance(3),
 		caseInsensitive(false),
+        comparisonMethod(Levenshtein),
 		showAllMatches(false),
 		showTotals(false),
 		ignoreNonAlphaNumeric(false)
 		{}
 
-	unsigned int maxEditDistance;
+	float maxDistance;
 	bool caseInsensitive;
+	ComparisonMethod comparisonMethod;
 	bool showAllMatches;
 	bool showTotals;
 	bool ignoreNonAlphaNumeric;

--- a/lib/funiq/similarity.h
+++ b/lib/funiq/similarity.h
@@ -1,0 +1,36 @@
+#ifndef FUNIQ_SIMILARITY_H
+#define FUNIQ_SIMILARITY_H
+
+namespace similarity {
+
+	unsigned int levenshteinDistance(const std::string& s1, const std::string& s2) {
+		unsigned int len1 = s1.size();
+		unsigned int len2 = s2.size();
+		std::vector<unsigned int> col(len2+1);
+		std::vector<unsigned int> prevCol(len2+1);
+
+		for (unsigned int i = 0; i < prevCol.size(); i++) {
+			prevCol[i] = i;
+		}
+		for (unsigned int i = 0; i < len1; i++) {
+			col[0] = i+1;
+			for (unsigned int j = 0; j < len2; j++) {
+				col[j+1] = std::min(
+						std::min( 1 + col[j], 1 + prevCol[1 + j]),
+						prevCol[j] + (s1[i]==s2[j] ? 0 : 1)
+				);
+			}
+			col.swap(prevCol);
+		}
+		return prevCol[len2];
+	}
+
+	float normalizedLevenshtein(const std::string& s1, const std::string& s2) {
+		int editDistance = levenshteinDistance(s1, s2);
+		int maxLength = std::max(s1.length(), s2.length());
+		float res = (float)editDistance / (float)maxLength;
+		return res;
+	}
+}
+
+#endif //FUNIQ_SIMILARITY_H

--- a/src/funiq.cpp
+++ b/src/funiq.cpp
@@ -28,13 +28,13 @@ void parseCommandLine(int argc, char** argv, std::string& filename, Settings& se
 		false, 3, "number");
 	TCLAP::SwitchArg caseSwitch(
 		"i","case-insensitive",
-		"When active, case differences do not contribute to edit distance.");
+		"When active, case differences do not contribute to distance between strings.");
 	TCLAP::SwitchArg showAllSwitch(
 		"a","show-all",
 		"Will show all found duplicates");
 	TCLAP::SwitchArg showTotalsSwitch(
 		"c","show-counts",
-		"Precede each output line with the count of the number of times the line occurred"
+		"Precede each output line with the count of the number of times the line occurred "
 		"in the input, followed by a single space.");
 	TCLAP::SwitchArg ignoreNonAlphaNumericSwitch(
 		"I","ignore-non-alpha-numeric",

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -4,6 +4,7 @@
 #include "catch/catch.hpp"
 #include "funiq/Settings.h"
 #include "funiq/Matcher.h"
+#include "funiq/similarity.h"
 
 std::string getNextLine(std::stringstream *stream) {
     std::string line;
@@ -115,4 +116,18 @@ TEST_CASE( "Normalised Levenshtein setting for short and long strings", "[matche
 	REQUIRE(getNextLine(&output) == "monkey");
 	REQUIRE(getNextLine(&output) == "rat");
 	REQUIRE(getNextLine(&output) == "");
+}
+
+TEST_CASE( "similarity::levenshteinDistance returns correct values", "[levenshtein]" ) {
+	REQUIRE(similarity::levenshteinDistance("cat", "rat") == 1);
+	REQUIRE(similarity::levenshteinDistance("hello", "helo") == 1);
+	REQUIRE(similarity::levenshteinDistance("think", "thinky") == 1);
+	REQUIRE(similarity::levenshteinDistance("hair", "head") == 3);
+}
+
+TEST_CASE( "similarity::normalizedLevenshtein returns correct values", "[levenshtein]" ) {
+	REQUIRE(similarity::normalizedLevenshtein("fear", "wear") == 0.25);
+	REQUIRE(similarity::normalizedLevenshtein("here", "hear") == 0.5);
+	REQUIRE(similarity::normalizedLevenshtein("not", "yes") == 1);
+	REQUIRE(similarity::normalizedLevenshtein("same", "same") == 0);
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -37,13 +37,14 @@ TEST_CASE( "First README example is correct", "[matcher]" ) {
     REQUIRE(getNextLine(&output) == "The Flopship of the Rung");
     REQUIRE(getNextLine(&output) == "The Return of the King");
     REQUIRE(getNextLine(&output) == "The Two Towers");
+    REQUIRE(getNextLine(&output) == "");
 }
 
 TEST_CASE( "Second README example is correct", "[matcher]" ) {
     Settings settings;
     settings.caseInsensitive = true;
     settings.ignoreNonAlphaNumeric = true;
-    settings.maxEditDistance = 4;
+    settings.maxDistance = 4;
 
     Matcher matcher(settings);
 
@@ -64,4 +65,54 @@ TEST_CASE( "Second README example is correct", "[matcher]" ) {
     REQUIRE(getNextLine(&output) == "The Fellowship of The Ring");
     REQUIRE(getNextLine(&output) == "The Return of the King");
     REQUIRE(getNextLine(&output) == "The Two Towers");
+    REQUIRE(getNextLine(&output) == "");
+}
+
+TEST_CASE( "Normalised Levenshtein setting for short strings", "[matcher]" ) {
+    Settings settings;
+    settings.comparisonMethod = NormalizedLevenshtein;
+
+	// _foo -> _ normalized distance is 0.75
+	// _foo -> _moo normalized distance is 0.25
+    settings.maxDistance = 0.26;
+
+    Matcher matcher(settings);
+
+    matcher.add("_");
+    matcher.add("_foo");
+    matcher.add("_moo");
+
+    std::stringstream output;
+    matcher.show(&output);
+
+    REQUIRE(getNextLine(&output) == "_");
+    REQUIRE(getNextLine(&output) == "_foo");
+    REQUIRE(getNextLine(&output) == "");
+}
+
+TEST_CASE( "Normalised Levenshtein setting for short and long strings", "[matcher]" ) {
+	Settings settings;
+	settings.comparisonMethod = NormalizedLevenshtein;
+	settings.maxDistance = 0.35;
+
+	Matcher matcher(settings);
+
+	// One character difference
+	matcher.add("rat");
+	matcher.add("cat");
+
+	// Two character difference
+	matcher.add("elephant");
+	matcher.add("elephenty");
+
+	// All different
+	matcher.add("monkey");
+
+	std::stringstream output;
+	matcher.show(&output);
+
+	REQUIRE(getNextLine(&output) == "elephant");
+	REQUIRE(getNextLine(&output) == "monkey");
+	REQUIRE(getNextLine(&output) == "rat");
+	REQUIRE(getNextLine(&output) == "");
 }


### PR DESCRIPTION
As per @ComedyTomedy's feature request in #4 , this PR introduces the ability to use a normalized Levenshtein distance metric.

Under this metric, distances are a value between 0 and 1. This is useful to allow comparing shorter strings alongside longer ones - the distance becomes a proportion of a string's length, rather than an absolute number of character changes. It allows a user to effectively say "consider strings as duplicates if they are up to 25% similar".

I've:
* Added a new flag, `-m`, which allows the comparison method to be specified
* Generalised the `-d` flag to represent a more general concept of distance; if `-m normalized-levenshtein` is selected, the `-d` flag will take a number between 0 and 1

The default is still non-normalized Levenshtein - which preserves existing behaviour.